### PR TITLE
chore: add CI/CD for PyPI publishing, documentation deployment, and complete README

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,58 @@
+name: Build Documentation
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Build documentation
+        run: |
+          cd docs
+          uv run sphinx-build -b html . _build/html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        with:
+          path: 'docs/_build/html'
+
+  deploy:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test and Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Lint with ruff
+        run: uv run ruff check athletics_performance tests
+
+      - name: Format check with ruff
+        run: uv run ruff format --check athletics_performance tests
+
+      - name: Run tests with pytest
+        run: uv run pytest --cov=athletics_performance --cov-report=term
+
+      - name: Build package
+        run: uv build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- GitHub Actions workflow for automated PyPI publishing on tagged releases
+- GitHub Actions workflow for automated documentation deployment to GitHub Pages
+- GitHub Actions workflow for testing and linting on all PRs and pushes
+- PyPI and build status badges in README
+- Release process documentation in README
+
+### Changed
+- Enhanced README with development setup instructions and release process guide
+
+## Previous Releases
+
+- See [GitHub Releases](https://github.com/AthleticClubLyonnais/athletics-performance/releases) for historical release notes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # athletics-performance
 
+[![PyPI version](https://badge.fury.io/py/athletics_performance.svg)](https://pypi.org/project/athletics_performance/)
+[![Test and Lint](https://github.com/AthleticClubLyonnais/athletics-performance/workflows/Test%20and%20Lint/badge.svg)](https://github.com/AthleticClubLyonnais/athletics-performance/actions)
+[![Documentation](https://github.com/AthleticClubLyonnais/athletics-performance/workflows/Build%20Documentation/badge.svg)](https://github.com/AthleticClubLyonnais/athletics-performance/actions)
+
 Python package for managing athletics results data — athletes, clubs, events, and performances — following a normalised relational model.
 
 Built for the **Athletic Club du Lyonnais (ACL)**.
@@ -77,5 +81,41 @@ performances  perf_id (PK), athlete_id (FK), event_id (FK), date, result_value,
 
 To contribute to the project, please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Quick start with development
+
+```bash
+# Clone and set up environment
+git clone https://github.com/AthleticClubLyonnais/athletics-performance.git
+cd athletics-performance
+
+# Install with uv (Python 3.13+)
+uv sync --all-groups
+uv run pre-commit install
+
+# Run tests
+uv run pytest --cov
+
+# Lint and format
+uv run ruff check .
+uv run ruff format .
+
+# Build documentation locally
+cd docs
+uv run sphinx-autobuild . _build/html
+```
+
+## Release Process
+
+1. Update version in commits/tags (tags determine publication)
+2. Create a PR with your changes
+3. Merge to `main`
+4. Create a git tag: `git tag v1.0.0` (matches `v*` pattern)
+5. Push tag: `git push origin v1.0.0`
+6. GitHub Actions automatically:
+   - Runs tests and linting
+   - Builds and publishes to [PyPI](https://pypi.org/project/athletics_performance/)
+   - Deploys documentation to GitHub Pages
+
 ## License
-[ACL](LICENSE.txt)
+
+This project is licensed under the [ACL License](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -4,21 +4,18 @@
 [![Test and Lint](https://github.com/AthleticClubLyonnais/athletics-performance/workflows/Test%20and%20Lint/badge.svg)](https://github.com/AthleticClubLyonnais/athletics-performance/actions)
 [![Documentation](https://github.com/AthleticClubLyonnais/athletics-performance/workflows/Build%20Documentation/badge.svg)](https://github.com/AthleticClubLyonnais/athletics-performance/actions)
 
-Python package for managing athletics results data — athletes, clubs, events, and performances — following a normalised relational model.
+A Python library for managing athletics results data — athletes, clubs, events, performances, and scoring tables — following a normalised relational model.
 
 Built for the **Athletic Club du Lyonnais (ACL)**.
 
-## Package contents
+## Features
 
-| Module | Class / Object | Description |
-|---|---|---|
-| `athlete` | `Athlete` | Frozen dataclass: `licence`, `last_name`, `first_name`, `yob`, `sex`. Computes FFA age-group category via `category(yos)` and `category_code(yob, yos[, sex])`. |
-| `club` | `Club` | Frozen dataclass: `club_id` (6 chars), `name`. Auto-derives `dept_code`, `ligue_code`, `ligue_name` from the club ID. |
-| `club` | `DEPARTMENT_TO_LIGUE` | Mapping `dept_code → (ligue_code, ligue_name)` for all French departments + DOM-COM. |
-| `club_membership` | `ClubMembership` | Tracks an athlete's membership period in a club (`athlete_id`, `club_id`, `start_date`, `end_date`). |
-| `event` | `Event` | Frozen dataclass: `event_id`, `name`, `measurement` (`"time"`/`"distance"`), `unit` (`"s"`/`"m"`). |
-| `performance` | `Performance` | Normalised performance record. Accepts `Athlete`/`Event` objects or raw IDs. Parses result strings, handles date formats, computes `yos` (year of season). |
-| `scoring_tables` | `ScoringTables` | World Athletics scoring table calculator. |
+- **Athlete & Club Models** — Immutable dataclasses with automatic category computation and department/league derivation
+- **Event Catalog** — Pre-configured events with measurement types (time/distance)
+- **Performance Records** — Normalised performance data with automatic year-of-season computation
+- **Performance Catalogue** — Query, filter, rank, and analyze collections of performances
+- **World Athletics Scoring Tables** — Official 2025 scoring table lookup system with PDF-to-parquet conversion
+- **Membership Tracking** — Track athlete club membership with active/inactive status
 
 ## Installation
 
@@ -26,35 +23,97 @@ Built for the **Athletic Club du Lyonnais (ACL)**.
 pip install athletics_performance
 ```
 
-## Quick start
+Requires Python 3.13+
+
+## Quick Start
+
+### Athlete Management
 
 ```python
-from datetime import date
-from athletics_performance import Athlete, Club, Event, ClubMembership, Performance
+from athletics_performance import Athlete
 
-# Athlete
-athlete = Athlete(licence="2275784", last_name="Perrin", first_name="Guillaume", yob=1982, sex="M")
-print(athlete.full_name)          # "Guillaume Perrin"
-print(athlete.category(2026))     # "M1M"
+# Create an athlete
+athlete = Athlete(
+    licence="2275784",
+    last_name="Perrin",
+    first_name="Guillaume",
+    yob=1982,
+    sex="M"
+)
 
-# Club (dept_code and ligue derived automatically from club_id)
+print(athlete.full_name)           # "Guillaume Perrin"
+print(athlete.category(yos=2026))  # "M1M" (age category)
+```
+
+### Club Management
+
+```python
+from athletics_performance import Club, DEPARTMENT_TO_LIGUE
+
+# Create a club
 club = Club(club_id="069106", name="ACL")
+
+# Automatically derived attributes
 print(club.dept_code)    # "069"
 print(club.ligue_code)   # "ARA"
 print(club.ligue_name)   # "Auvergne-Rhône-Alpes"
 
-# Club membership
-membership = ClubMembership(athlete_id="2275784", club_id="069106", start_date=date(2022, 1, 1))
-print(membership.is_active())   # True
+# Access department-to-league mapping
+print(DEPARTMENT_TO_LIGUE["069"])  # ("ARA", "Auvergne-Rhône-Alpes")
+```
 
-# Event
+### Club Membership
+
+```python
+from datetime import date
+from athletics_performance import ClubMembership
+
+# Track athlete club membership
+membership = ClubMembership(
+    athlete_id="2275784",
+    club_id="069106",
+    start_date=date(2022, 1, 1),
+    end_date=None  # Still active
+)
+
+print(membership.is_active())  # True
+```
+
+### Events
+
+```python
+from athletics_performance import Event, EVENT_CATALOG
+
+# Create a custom event
+event = Event(
+    event_id="100m",
+    name="100 mètres",
+    measurement="time",
+    unit="s"
+)
+
+# Access pre-configured event catalog
+sprint = EVENT_CATALOG["100m"]
+jump = EVENT_CATALOG["LJ"]  # Long jump
+
+print(jump.measurement)  # "distance"
+print(jump.unit)         # "m"
+```
+
+### Performance Records
+
+```python
+from datetime import date
+from athletics_performance import Athlete, Event, Performance
+
+athlete = Athlete(licence="2275784", last_name="Perrin", first_name="Guillaume", yob=1982, sex="M")
 event = Event(event_id="100m", name="100 mètres", measurement="time", unit="s")
 
-# Performance (via Athlete + Event objects, or raw IDs)
+# Create performance with object references
 perf = Performance(
     perf_id="P1",
     date=date(2026, 3, 15),
-    result_value="12.34",
+    result_value=12.34,
     measurement="time",
     unit="s",
     athlete=athlete,
@@ -62,60 +121,243 @@ perf = Performance(
     club_id_snapshot="069106",
     category_snapshot="M1M",
 )
-print(perf.result_value)   # 12.34
-print(perf.yos)            # 2026
+
+print(perf.result_value)  # 12.34
+print(perf.yos)           # 2026 (year of season)
+
+# Or create with raw IDs
+perf2 = Performance(
+    perf_id="P2",
+    date=date(2026, 4, 10),
+    result_value=12.10,
+    measurement="time",
+    unit="s",
+    athlete_id="2275784",
+    event_id="100m",
+)
 ```
 
-## Data model
+### Performance Catalogue
+
+```python
+from datetime import date
+from athletics_performance import Performance, PerformanceCatalogue
+
+# Create a collection of performances
+p1 = Performance(perf_id="P1", date=date(2026, 3, 15), result_value=12.34,
+                 measurement="time", unit="s", athlete_id="A1", event_id="100m")
+p2 = Performance(perf_id="P2", date=date(2026, 4, 10), result_value=11.90,
+                 measurement="time", unit="s", athlete_id="A2", event_id="100m")
+
+cat = PerformanceCatalogue([p1, p2])
+
+# Collection operations
+print(len(cat))                    # 2
+print(cat.record())                # Best performance (11.90)
+print(cat.by_athlete_id("A1"))    # Performances by A1
+
+# Chaining operations
+filtered = cat.by_event_id("100m").by_athlete_id("A1")
+
+# Statistics
+cat.mean_result()  # Average result
+cat.median_result() # Median result
+```
+
+### World Athletics Scoring Tables
+
+```python
+from athletics_performance import ScoringTables
+
+# Load the pre-built scoring tables
+tables = ScoringTables.load()
+
+# Look up points for a performance
+points = tables.lookup(sex="M", event="100m", performance=12.34)
+print(points)  # World Athletics points for 12.34s in men's 100m
+```
+
+## API Reference
+
+### Core Classes
+
+| Class | Purpose |
+|-------|---------|
+| **Athlete** | Immutable athlete record with licence, name, birth year, sex, and age-category computation |
+| **Club** | Club information with automatic department and league derivation |
+| **Event** | Event definition with measurement type (time/distance) and unit (s/m) |
+| **Performance** | Single performance record with athlete, event, result, and date |
+| **PerformanceCatalogue** | Ordered collection of Performance objects with filtering, ranking, and statistics |
+| **ClubMembership** | Track athlete membership in a club with active/inactive status |
+| **ScoringTables** | World Athletics 2025 scoring table lookups |
+
+### Constants
+
+| Name | Purpose |
+|------|---------|
+| **EVENT_CATALOG** | Pre-configured dictionary of standard athletics events |
+| **DEPARTMENT_TO_LIGUE** | Mapping from French department codes to league codes and names |
+
+## Data Model
 
 ```
-athletes      licence (PK), last_name, first_name, yob, sex
-clubs         club_id (PK, 6 chars), name  →  dept_code, ligue_code, ligue_name
-events        event_id (PK), name, measurement, unit
-memberships   athlete_id (FK), club_id (FK), start_date, end_date
-performances  perf_id (PK), athlete_id (FK), event_id (FK), date, result_value,
-              measurement, unit, venue, club_id_snapshot, category_snapshot, notes
+athletes
+  ├─ licence (PK)
+  ├─ last_name
+  ├─ first_name
+  ├─ yob (year of birth)
+  └─ sex ("F" or "M")
+
+clubs
+  ├─ club_id (PK, 6 chars)
+  ├─ name
+  ├─ dept_code (derived)
+  ├─ ligue_code (derived)
+  └─ ligue_name (derived)
+
+events
+  ├─ event_id (PK)
+  ├─ name
+  ├─ measurement ("time" or "distance")
+  └─ unit ("s" or "m")
+
+memberships
+  ├─ athlete_id (FK → athletes)
+  ├─ club_id (FK → clubs)
+  ├─ start_date
+  └─ end_date (nullable)
+
+performances
+  ├─ perf_id (PK)
+  ├─ athlete_id (FK → athletes)
+  ├─ event_id (FK → events)
+  ├─ date
+  ├─ result_value
+  ├─ measurement ("time" or "distance")
+  ├─ unit ("s" or "m")
+  ├─ venue
+  ├─ club_id_snapshot
+  ├─ category_snapshot
+  └─ notes
 ```
 
 ## Development
 
-To contribute to the project, please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
-
-### Quick start with development
+### Setup
 
 ```bash
-# Clone and set up environment
+# Clone repository
 git clone https://github.com/AthleticClubLyonnais/athletics-performance.git
 cd athletics-performance
 
-# Install with uv (Python 3.13+)
+# Install development environment (Python 3.13+)
 uv sync --all-groups
 uv run pre-commit install
+```
 
-# Run tests
-uv run pytest --cov
+### Running Tests
 
-# Lint and format
-uv run ruff check .
-uv run ruff format .
+```bash
+# Run all tests with coverage
+uv run pytest --cov=athletics_performance --cov-report=term
 
+# Run a specific test file
+uv run pytest tests/test_athlete.py
+
+# Run tests matching a pattern
+uv run pytest -k "category"
+```
+
+### Code Quality
+
+```bash
+# Lint code
+uv run ruff check athletics_performance tests
+
+# Format code
+uv run ruff format athletics_performance tests
+
+# Check formatting without changing
+uv run ruff format --check athletics_performance tests
+```
+
+### Documentation
+
+```bash
 # Build documentation locally
 cd docs
 uv run sphinx-autobuild . _build/html
+
+# Then visit http://localhost:8000
+```
+
+### Common Tasks
+
+```bash
+# Run all pre-commit checks
+uv run pre-commit run --all-files
+
+# Run tests, lint, and format
+task test
+task pre-commit
+
+# Build the package
+uv build
 ```
 
 ## Release Process
 
-1. Update version in commits/tags (tags determine publication)
-2. Create a PR with your changes
-3. Merge to `main`
-4. Create a git tag: `git tag v1.0.0` (matches `v*` pattern)
-5. Push tag: `git push origin v1.0.0`
-6. GitHub Actions automatically:
-   - Runs tests and linting
-   - Builds and publishes to [PyPI](https://pypi.org/project/athletics_performance/)
+### Creating a Release
+
+1. **Prepare changes** on your branch
+2. **Create PR** and merge to `main`
+3. **Create a git tag** matching `v*`:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+4. **GitHub Actions automatically**:
+   - Runs all tests and linting checks
+   - Builds the distribution
+   - Publishes to [PyPI](https://pypi.org/project/athletics_performance/)
    - Deploys documentation to GitHub Pages
+
+### Version Management
+
+- Versions are determined by git tags (e.g., `v1.0.0`)
+- The VERSION file is kept in sync and should not be manually edited
+- Follow [Semantic Versioning](https://semver.org/) for tag names
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines and [CHANGELOG.md](CHANGELOG.md) for release history.
+
+## Testing
+
+The repository includes unit tests and light integration tests:
+
+```bash
+# Run with coverage report
+uv run pytest --cov=athletics_performance --cov-report=html
+
+# View coverage report
+open htmlcov/index.html
+```
+
+## Documentation
+
+Full documentation is available at the project's documentation site (built from `docs/`).
+
+Generated via Sphinx with numpydoc-style docstrings.
 
 ## License
 
 This project is licensed under the [ACL License](LICENSE.txt).
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
+
+- Setting up your development environment
+- Running tests and pre-commit checks
+- Creating feature branches and pull requests
+- Release procedures and tagging conventions

--- a/notebooks/performance_catalogue.ipynb
+++ b/notebooks/performance_catalogue.ipynb
@@ -2,10 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "setup",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
@@ -43,10 +52,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "sample-data",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PerformanceCatalogue(19 performances)\n",
+      "Events covered: {'LJ', '100m'}\n",
+      "Athletes:       {'1004', '1002', '1003', '1001'}\n"
+     ]
+    }
+   ],
    "source": [
     "# Athletes\n",
     "alice  = Athlete(licence=\"1001\", last_name=\"Moreau\",  first_name=\"Alice\",  yob=1998, sex=\"F\")\n",
@@ -74,29 +93,29 @@
     "\n",
     "# 100m performances — season 2025 and 2026\n",
     "perfs_100m = [\n",
-    "    p(\"T01\", alice,  event_100m, 13.10, date(2025, 5, 10), \"SEF\", \"069001\"),\n",
-    "    p(\"T02\", alice,  event_100m, 12.85, date(2025, 6, 20), \"SEF\", \"069001\"),\n",
-    "    p(\"T03\", alice,  event_100m, 12.60, date(2026, 3, 15), \"SEF\", \"069001\"),\n",
-    "    p(\"T04\", alice,  event_100m, 12.45, date(2026, 5, 22), \"SEF\", \"069001\"),\n",
-    "    p(\"T05\", claire, event_100m, 13.50, date(2025, 5, 10), \"ESF\", \"069001\"),\n",
-    "    p(\"T06\", claire, event_100m, 13.20, date(2026, 4, 18), \"ESF\", \"069001\"),\n",
-    "    p(\"T07\", claire, event_100m, 12.90, date(2026, 6,  5), \"ESF\", \"069001\"),\n",
-    "    p(\"T08\", bob,    event_100m, 11.40, date(2025, 5, 10), \"SEM\", \"069001\"),\n",
-    "    p(\"T09\", bob,    event_100m, 11.20, date(2025, 7, 12), \"SEM\", \"069001\"),\n",
-    "    p(\"T10\", bob,    event_100m, 10.95, date(2026, 4, 25), \"SEM\", \"069001\"),\n",
-    "    p(\"T11\", david,  event_100m, 11.80, date(2025, 6,  1), \"SEM\", \"069002\"),\n",
-    "    p(\"T12\", david,  event_100m, 11.55, date(2026, 5, 30), \"SEM\", \"069002\"),\n",
+    "    p(\"T01\", alice,  event_100m, 13.10, date(2025, 5, 10), \"SEF\", \"069069\"),\n",
+    "    p(\"T02\", alice,  event_100m, 12.85, date(2025, 6, 20), \"SEF\", \"069069\"),\n",
+    "    p(\"T03\", alice,  event_100m, 12.60, date(2026, 3, 15), \"SEF\", \"069069\"),\n",
+    "    p(\"T04\", alice,  event_100m, 12.45, date(2026, 5, 22), \"SEF\", \"069069\"),\n",
+    "    p(\"T05\", claire, event_100m, 13.50, date(2025, 5, 10), \"ESF\", \"069069\"),\n",
+    "    p(\"T06\", claire, event_100m, 13.20, date(2026, 4, 18), \"ESF\", \"069069\"),\n",
+    "    p(\"T07\", claire, event_100m, 12.90, date(2026, 6,  5), \"ESF\", \"069069\"),\n",
+    "    p(\"T08\", bob,    event_100m, 11.40, date(2025, 5, 10), \"SEM\", \"069106\"),\n",
+    "    p(\"T09\", bob,    event_100m, 11.20, date(2025, 7, 12), \"SEM\", \"069106\"),\n",
+    "    p(\"T10\", bob,    event_100m, 10.95, date(2026, 4, 25), \"SEM\", \"069106\"),\n",
+    "    p(\"T11\", david,  event_100m, 11.80, date(2025, 6,  1), \"SEM\", \"069106\"),\n",
+    "    p(\"T12\", david,  event_100m, 11.55, date(2026, 5, 30), \"SEM\", \"069106\"),\n",
     "]\n",
     "\n",
     "# Long jump performances\n",
     "perfs_lj = [\n",
-    "    p(\"J01\", alice,  event_lj, 5.20, date(2025, 5, 10), \"SEF\", \"069001\"),\n",
-    "    p(\"J02\", alice,  event_lj, 5.45, date(2026, 3, 15), \"SEF\", \"069001\"),\n",
-    "    p(\"J03\", alice,  event_lj, 5.60, date(2026, 5, 22), \"SEF\", \"069001\"),\n",
-    "    p(\"J04\", bob,    event_lj, 6.80, date(2025, 5, 10), \"SEM\", \"069001\"),\n",
-    "    p(\"J05\", bob,    event_lj, 7.05, date(2026, 4, 25), \"SEM\", \"069001\"),\n",
-    "    p(\"J06\", david,  event_lj, 6.40, date(2025, 6,  1), \"SEM\", \"069002\"),\n",
-    "    p(\"J07\", david,  event_lj, 6.65, date(2026, 5, 30), \"SEM\", \"069002\"),\n",
+    "    p(\"J01\", alice,  event_lj, 5.20, date(2025, 5, 10), \"SEF\", \"069069\"),\n",
+    "    p(\"J02\", alice,  event_lj, 5.45, date(2026, 3, 15), \"SEF\", \"069069\"),\n",
+    "    p(\"J03\", alice,  event_lj, 5.60, date(2026, 5, 22), \"SEF\", \"069069\"),\n",
+    "    p(\"J04\", bob,    event_lj, 6.80, date(2025, 5, 10), \"SEM\", \"069106\"),\n",
+    "    p(\"J05\", bob,    event_lj, 7.05, date(2026, 4, 25), \"SEM\", \"069106\"),\n",
+    "    p(\"J06\", david,  event_lj, 6.40, date(2025, 6,  1), \"SEM\", \"069106\"),\n",
+    "    p(\"J07\", david,  event_lj, 6.65, date(2026, 5, 30), \"SEM\", \"069106\"),\n",
     "]\n",
     "\n",
     "cat = PerformanceCatalogue(perfs_100m + perfs_lj)\n",
@@ -115,10 +134,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "building",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Built incrementally: PerformanceCatalogue(3 performances)\n",
+      "Merged (+ operator): PerformanceCatalogue(19 performances)\n"
+     ]
+    }
+   ],
    "source": [
     "# Start empty and add incrementally\n",
     "cat2 = PerformanceCatalogue()\n",
@@ -143,10 +171,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "filtering",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice's performances : 7\n",
+      "100m performances    : 12\n",
+      "Season 2026          : 10 performances\n",
+      "Spring 2026          : 9 performances\n",
+      "SEF category         : 7 performances\n",
+      "Alice / 100m / 2026  : 2 performances\n",
+      "  2026-03-15  12.6s\n",
+      "  2026-05-22  12.45s\n"
+     ]
+    }
+   ],
    "source": [
     "# By athlete\n",
     "alice_perfs = cat.filter(athlete_id=alice.licence)\n",
@@ -185,10 +228,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "records",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100m catalogue record : 10.95s  (athlete 1002, 2026-04-25)\n",
+      "LJ catalogue record   : 7.05m  (athlete 1002, 2026-04-25)\n",
+      "\n",
+      "Alice PB 100m : 12.45s  (2026-05-22)\n",
+      "\n",
+      "All personal bests:\n",
+      "  athlete  event  result\n",
+      "  1001     100m   12.45s\n",
+      "  1003     100m   12.9s\n",
+      "  1002     100m   10.95s\n",
+      "  1004     100m   11.55s\n",
+      "  1001     LJ     5.6m\n",
+      "  1002     LJ     7.05m\n",
+      "  1004     LJ     6.65m\n"
+     ]
+    }
+   ],
    "source": [
     "# Overall 100m record in the catalogue\n",
     "rec_100m = cat.filter(event_id=\"100m\").record()\n",
@@ -212,10 +276,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "records-per-event",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Season 2026 records:\n",
+      "  100m   10.95s  athlete=1002  date=2026-04-25\n",
+      "  LJ     7.05m  athlete=1002  date=2026-04-25\n"
+     ]
+    }
+   ],
    "source": [
     "# Records (best per event) within a given season\n",
     "print(\"Season 2026 records:\")\n",
@@ -233,10 +307,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "ranking",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100m ranking — season 2026\n",
+      "  pos  athlete    result\n",
+      "  1    1002       10.95s\n",
+      "  2    1004       11.55s\n",
+      "  3    1001       12.45s\n",
+      "  4    1003       12.90s\n",
+      "\n",
+      "Top 3 individual 100m performances (all time):\n",
+      "  10.95s  athlete=1002  date=2026-04-25\n",
+      "  11.20s  athlete=1002  date=2025-07-12\n",
+      "  11.40s  athlete=1002  date=2025-05-10\n"
+     ]
+    }
+   ],
    "source": [
     "# Season 2026 100m ranking (one PB per athlete, sorted best first)\n",
     "ranking_100m_2026 = cat.filter(event_id=\"100m\", yos=2026).ranking()\n",
@@ -265,10 +357,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "grouping-athlete",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Performances per athlete:\n",
+      "  1001 → 7 performances\n",
+      "  1002 → 5 performances\n",
+      "  1003 → 3 performances\n",
+      "  1004 → 4 performances\n"
+     ]
+    }
+   ],
    "source": [
     "# Group by athlete — how many performances each athlete has\n",
     "by_athlete = cat.group_by(\"athlete_id\")\n",
@@ -279,10 +383,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "grouping-season",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100m record progression by season:\n",
+      "  2025: 11.20s  (athlete 1002)\n",
+      "  2026: 10.95s  (athlete 1002)\n"
+     ]
+    }
+   ],
    "source": [
     "# Group by season — compare record progression year over year\n",
     "print(\"100m record progression by season:\")\n",
@@ -294,10 +408,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "grouping-category",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100m season-2026 ranking by category:\n",
+      "\n",
+      "  [ESF]\n",
+      "    1. athlete=1003  12.90s\n",
+      "\n",
+      "  [SEF]\n",
+      "    1. athlete=1001  12.45s\n",
+      "\n",
+      "  [SEM]\n",
+      "    1. athlete=1002  10.95s\n",
+      "    2. athlete=1004  11.55s\n"
+     ]
+    }
+   ],
    "source": [
     "# Group by category — ranking per category for a single event and season\n",
     "print(\"100m season-2026 ranking by category:\")\n",
@@ -319,10 +451,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "stats",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100m overall stats:\n",
+      "  count   : 12\n",
+      "  min     : 10.9500\n",
+      "  max     : 13.5000\n",
+      "  mean    : 12.2917\n",
+      "  median  : 12.5250\n",
+      "  stdev   : 0.8696\n",
+      "\n",
+      "100m stats per season:\n",
+      "  2025: count=6  mean=12.31s  best=11.20s\n",
+      "  2026: count=6  mean=12.28s  best=10.95s\n"
+     ]
+    }
+   ],
    "source": [
     "# Stats on all 100m performances\n",
     "s = cat.filter(event_id=\"100m\").stats()\n",
@@ -351,10 +501,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "composed-progression",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice's 100m progression (Alice Moreau):\n",
+      "  Season 2025: 12.85s  (2025-06-20)\n",
+      "  Season 2026: 12.45s  (2026-05-22)\n"
+     ]
+    }
+   ],
    "source": [
     "# Athlete progression: best 100m per season for Alice\n",
     "print(f\"Alice's 100m progression ({alice.full_name}):\")\n",
@@ -366,22 +526,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "composed-club",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Club 069069 — 100m record: 12.45s  (athlete 1001, 2026-05-22)\n"
+     ]
+    }
+   ],
    "source": [
-    "# Club record for 100m (only athletes from club 069001)\n",
-    "club_rec = cat.filter(event_id=\"100m\", club_id=\"069001\").record()\n",
-    "print(f\"Club 069001 — 100m record: {club_rec.result_value:.2f}s  (athlete {club_rec.athlete_id}, {club_rec.date})\")"
+    "# Club record for 100m (only athletes from club 069069)\n",
+    "club_rec = cat.filter(event_id=\"100m\", club_id=\"069069\").record()\n",
+    "print(f\"Club 069069 — 100m record: {club_rec.result_value:.2f}s  (athlete {club_rec.athlete_id}, {club_rec.date})\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "composed-multi-event",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All-time personal bests across all events:\n",
+      "  athlete  event  result\n",
+      "  1002     100m   10.95s\n",
+      "  1004     100m   11.55s\n",
+      "  1001     100m   12.45s\n",
+      "  1003     100m   12.9s\n",
+      "  1001     LJ     5.6m\n",
+      "  1004     LJ     6.65m\n",
+      "  1002     LJ     7.05m\n"
+     ]
+    }
+   ],
    "source": [
     "# All-time personal bests per athlete across all events, sorted by event then result\n",
     "print(\"All-time personal bests across all events:\")\n",
@@ -394,13 +578,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.13.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflows for automated PyPI publishing (on `v*` tags), test/lint CI, and GitHub Pages documentation deployment
- Add `CHANGELOG.md` with Keep a Changelog format
- Rewrite `README.md` with complete API reference covering all 7 classes and 2 constants, full code examples, data model diagram, and release process guide

## Setup required before merging

- [ ] Add `PYPI_API_TOKEN` as a GitHub Actions secret (generate at https://pypi.org/manage/account/tokens/)
- [ ] Enable GitHub Pages in repo settings → source: GitHub Actions

## Test plan

- [ ] Verify CI workflow passes on this PR
- [ ] Review README renders correctly on GitHub
- [ ] After merge, create a `v*` tag and confirm PyPI publish workflow triggers